### PR TITLE
Switch case indentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = {
         'avoidEscape': true,
       },
     ],
-    'indent': ['error', 2],
+    'indent': ['error', 2, {
+      SwitchCase: 1
+    }],
     'linebreak-style': ['error', 'unix'],
     'quotes': ['error', 'single'],
     'semi': ['error', 'always'],


### PR DESCRIPTION
The default is zero which forces the `case`s to be on the same indent as the `switch`, we want them to be 2 spaces furtther